### PR TITLE
test(Fase B): adaptadores — visualizadores, proxies y estado consolidado

### DIFF
--- a/Test/integration/adaptadores/test_proxies.py
+++ b/Test/integration/adaptadores/test_proxies.py
@@ -9,11 +9,23 @@ Casos de prueba del Plan de Pruebas:
 
 - PST-001: Archivo existe -> retorna valor
 - PST-002: Archivo no existe -> Exception
+
+- PRX-SET-001: SeteoTemperatura.obtener_seteo desde consola
+- PRX-SET-002: SeteoTemperaturaSocket init con host/puerto
+- PRX-SET-003: SeteoTemperaturaSocket.obtener_seteo mock socket exitoso
+- PRX-SET-004: SeteoTemperaturaSocket como context manager
+- PRX-SET-005: SeteoTemperaturaSocket.__exit__ cierra recursos
+- PRX-SNS-001: ProxySensorTemperaturaSocket con mock socket
+- PRX-BAT-001: ProxyBateriaSocket con host y puerto correctos
 """
 import pytest
 from unittest.mock import Mock, patch, mock_open
 from agentes_sensores.proxy_bateria import ProxyBateriaArchivo, ProxyBateriaSocket
-from agentes_sensores.proxy_sensor_temperatura import ProxySensorTemperaturaArchivo
+from agentes_sensores.proxy_sensor_temperatura import (
+    ProxySensorTemperaturaArchivo,
+    ProxySensorTemperaturaSocket,
+)
+from agentes_sensores.proxy_seteo_temperatura import SeteoTemperatura, SeteoTemperaturaSocket
 
 
 class TestProxyBateriaArchivo:
@@ -147,3 +159,91 @@ class TestProxiesIntegracion:
             proxy = ProxySensorTemperaturaArchivo()
             temp = proxy.leer_temperatura()
             assert temp == 23
+
+
+class TestSeteoTemperatura:
+
+    # PRX-SET-001
+    def test_obtener_seteo_opcion_1_retorna_aumentar(self):
+        """Con input '1', obtener_seteo retorna 'aumentar'"""
+        with patch("builtins.input", return_value="1"):
+            proxy = SeteoTemperatura()
+            assert proxy.obtener_seteo() == "aumentar"
+
+    def test_obtener_seteo_opcion_2_retorna_disminuir(self):
+        """Con input '2', obtener_seteo retorna 'disminuir'"""
+        with patch("builtins.input", return_value="2"):
+            proxy = SeteoTemperatura()
+            assert proxy.obtener_seteo() == "disminuir"
+
+
+class TestSeteoTemperaturaSocket:
+
+    @pytest.fixture
+    def mock_servidor(self):
+        mock = Mock()
+        mock.accept.side_effect = __import__("socket").timeout
+        return mock
+
+    # PRX-SET-002
+    def test_init_conexion_es_none(self, mock_servidor):
+        """Al instanciar con host/puerto, _conexion es None"""
+        with patch("socket.socket", return_value=mock_servidor):
+            proxy = SeteoTemperaturaSocket("0.0.0.0", 13000)
+        assert proxy._conexion is None
+
+    # PRX-SET-003
+    def test_obtener_seteo_socket_exitoso_retorna_valor(self, mock_servidor):
+        """Con datos recibidos por socket, retorna el comando enviado"""
+        mock_conn = Mock()
+        mock_conn.recv.return_value = b"aumentar"
+        mock_servidor.accept.side_effect = None
+        mock_servidor.accept.return_value = (mock_conn, ("127.0.0.1", 5000))
+
+        with patch("socket.socket", return_value=mock_servidor):
+            proxy = SeteoTemperaturaSocket("0.0.0.0", 13000)
+            resultado = proxy.obtener_seteo()
+
+        assert resultado == "aumentar"
+
+    # PRX-SET-004
+    def test_context_manager_enter_retorna_self(self, mock_servidor):
+        """__enter__ retorna la instancia del proxy"""
+        with patch("socket.socket", return_value=mock_servidor):
+            proxy = SeteoTemperaturaSocket("0.0.0.0", 13000)
+            assert proxy.__enter__() is proxy
+
+    # PRX-SET-005
+    def test_context_manager_exit_cierra_servidor(self, mock_servidor):
+        """__exit__ cierra el servidor socket"""
+        with patch("socket.socket", return_value=mock_servidor):
+            proxy = SeteoTemperaturaSocket("0.0.0.0", 13000)
+            proxy.__exit__(None, None, None)
+        mock_servidor.close.assert_called_once()
+
+
+class TestProxySensorTemperaturaSocket:
+
+    # PRX-SNS-001
+    def test_leer_temperatura_socket_exitoso(self):
+        """Con datos recibidos por socket, retorna la temperatura como float"""
+        mock_servidor = Mock()
+        mock_conn = Mock()
+        mock_conn.recv.side_effect = [b"25.0", b""]
+        mock_servidor.accept.return_value = (mock_conn, ("127.0.0.1", 5000))
+
+        with patch("socket.socket", return_value=mock_servidor):
+            proxy = ProxySensorTemperaturaSocket("0.0.0.0", 12000)
+            temperatura = proxy.leer_temperatura()
+
+        assert temperatura == 25.0
+
+
+class TestProxyBateriaSocketDI:
+
+    # PRX-BAT-001
+    def test_init_almacena_host_y_puerto(self):
+        """El constructor almacena host y puerto correctamente"""
+        proxy = ProxyBateriaSocket("192.168.1.1", 11000)
+        assert proxy._host == "192.168.1.1"
+        assert proxy._puerto == 11000

--- a/Test/integration/adaptadores/test_visualizadores.py
+++ b/Test/integration/adaptadores/test_visualizadores.py
@@ -9,11 +9,22 @@ Casos de prueba del Plan de Pruebas:
 - VIS-005: API no disponible -> RequestException manejado
 """
 import pytest
+import requests
 from unittest.mock import Mock, patch, MagicMock
 from agentes_actuadores.visualizador_temperatura import (
     VisualizadorTemperatura,
     VisualizadorTemperaturaSocket,
     VisualizadorTemperaturaApi
+)
+from agentes_actuadores.visualizador_bateria import (
+    VisualizadorBateria,
+    VisualizadorBateriaSocket,
+    VisualizadorBateriaApi,
+)
+from agentes_actuadores.visualizador_climatizador import (
+    VisualizadorClimatizador,
+    VisualizadorClimatizadorSocket,
+    VisualizadorClimatizadorApi,
 )
 
 
@@ -213,3 +224,136 @@ class TestVisualizadoresIntegracion:
         with patch('requests.post') as mock_post:
             vis_api.mostrar_temperatura_ambiente(25.5)
             mock_post.assert_called()
+
+
+class TestVisualizadorBateriaConsola:
+
+    # VIS-B-001
+    def test_mostrar_tension_imprime_en_consola(self, capsys):
+        """mostrar_tension imprime el valor en consola"""
+        vis = VisualizadorBateria()
+        vis.mostrar_tension(4.2)
+        assert "4.2" in capsys.readouterr().out
+
+    # VIS-B-002
+    def test_mostrar_indicador_imprime_en_consola(self, capsys):
+        """mostrar_indicador imprime el valor en consola"""
+        vis = VisualizadorBateria()
+        vis.mostrar_indicador("NORMAL")
+        assert "NORMAL" in capsys.readouterr().out
+
+
+class TestVisualizadorBateriaSocket:
+
+    # VIS-B-003
+    def test_mostrar_tension_envia_al_socket(self):
+        """mostrar_tension envía los datos al socket"""
+        mock_socket = Mock()
+        vis = VisualizadorBateriaSocket("localhost", 11000)
+        with patch("socket.socket", return_value=mock_socket):
+            vis.mostrar_tension(4.2)
+        mock_socket.connect.assert_called_once_with(("localhost", 11000))
+        mock_socket.send.assert_called_once()
+        mock_socket.close.assert_called_once()
+
+    # VIS-B-004
+    def test_mostrar_indicador_envia_al_socket(self):
+        """mostrar_indicador envía los datos al socket"""
+        mock_socket = Mock()
+        vis = VisualizadorBateriaSocket("localhost", 11000)
+        with patch("socket.socket", return_value=mock_socket):
+            vis.mostrar_indicador("BAJA")
+        mock_socket.connect.assert_called_once_with(("localhost", 11000))
+        mock_socket.send.assert_called_once()
+
+    # VIS-C-004
+    def test_connection_error_no_propaga_excepcion(self):
+        """Cuando el socket falla, no propaga la excepcion"""
+        mock_socket = Mock()
+        mock_socket.connect.side_effect = ConnectionError("refused")
+        vis = VisualizadorBateriaSocket("localhost", 11000)
+        with patch("socket.socket", return_value=mock_socket):
+            vis.mostrar_tension(4.2)  # No debe lanzar excepcion
+
+
+class TestVisualizadorBateriaApi:
+
+    # VIS-B-005
+    def test_mostrar_tension_hace_post_a_api(self):
+        """mostrar_tension hace POST al endpoint correcto"""
+        vis = VisualizadorBateriaApi("http://localhost:5050")
+        with patch("requests.post") as mock_post:
+            vis.mostrar_tension(4.2)
+        mock_post.assert_called_once_with(
+            "http://localhost:5050/termostato/bateria/",
+            json={"bateria": 4.2},
+            timeout=5
+        )
+
+    # VIS-B-006
+    def test_mostrar_indicador_no_hace_post(self):
+        """mostrar_indicador es no-op en la implementacion API"""
+        vis = VisualizadorBateriaApi("http://localhost:5050")
+        with patch("requests.post") as mock_post:
+            vis.mostrar_indicador("NORMAL")
+        mock_post.assert_not_called()
+
+    # VIS-C-005
+    def test_request_exception_no_propaga_excepcion(self):
+        """Cuando la API falla, no propaga la excepcion"""
+        vis = VisualizadorBateriaApi("http://localhost:5050")
+        with patch("requests.post", side_effect=requests.RequestException("timeout")):
+            vis.mostrar_tension(4.2)  # No debe lanzar excepcion
+
+
+class TestVisualizadorClimatizadorConsola:
+
+    # VIS-C-001
+    def test_mostrar_estado_imprime_en_consola(self, capsys):
+        """mostrar_estado_climatizador imprime el estado en consola"""
+        vis = VisualizadorClimatizador()
+        vis.mostrar_estado_climatizador("calentando")
+        assert "calentando" in capsys.readouterr().out
+
+
+class TestVisualizadorClimatizadorSocket:
+
+    # VIS-C-002
+    def test_mostrar_estado_envia_al_socket(self):
+        """mostrar_estado_climatizador envía el estado al socket"""
+        mock_socket = Mock()
+        vis = VisualizadorClimatizadorSocket("localhost", 14002)
+        with patch("socket.socket", return_value=mock_socket):
+            vis.mostrar_estado_climatizador("apagado")
+        mock_socket.connect.assert_called_once_with(("localhost", 14002))
+        mock_socket.send.assert_called_once()
+        mock_socket.close.assert_called_once()
+
+    def test_connection_error_no_propaga_excepcion(self):
+        """Cuando el socket falla, no propaga la excepcion"""
+        mock_socket = Mock()
+        mock_socket.connect.side_effect = ConnectionError("refused")
+        vis = VisualizadorClimatizadorSocket("localhost", 14002)
+        with patch("socket.socket", return_value=mock_socket):
+            vis.mostrar_estado_climatizador("apagado")  # No debe lanzar excepcion
+
+
+class TestVisualizadorClimatizadorApi:
+
+    # VIS-C-003
+    def test_mostrar_estado_hace_post_a_api(self):
+        """mostrar_estado_climatizador hace POST al endpoint correcto"""
+        vis = VisualizadorClimatizadorApi("http://localhost:5050")
+        with patch("requests.post") as mock_post:
+            vis.mostrar_estado_climatizador("enfriando")
+        mock_post.assert_called_once_with(
+            "http://localhost:5050/termostato/estado_climatizador/",
+            json={"climatizador": "enfriando"},
+            timeout=5
+        )
+
+    def test_request_exception_no_propaga_excepcion(self):
+        """Cuando la API falla, no propaga la excepcion"""
+        vis = VisualizadorClimatizadorApi("http://localhost:5050")
+        with patch("requests.post", side_effect=requests.RequestException("timeout")):
+            vis.mostrar_estado_climatizador("apagado")  # No debe lanzar excepcion

--- a/Test/unit/agentes_actuadores/test_visualizador_estado_consolidado.py
+++ b/Test/unit/agentes_actuadores/test_visualizador_estado_consolidado.py
@@ -1,0 +1,173 @@
+"""
+Tests unitarios para agentes_actuadores/visualizador_estado_consolidado.py
+
+Casos de prueba:
+- VEC-001: Constructor con host y puerto -> almacena correctamente
+- VEC-002: mostrar_estado_completo envia JSON por socket (mock)
+- VEC-003: Formato JSON contiene los 8 campos del contrato de API
+- VEC-004: _construir_estado con temperatura None -> falla_sensor=True y temp=0.0
+- VEC-005: _construir_estado con bateria BAJA -> bateria_baja=True
+- VEC-006: _mapear_modo_climatizador("apagado") -> "reposo"
+- VEC-007: _mapear_modo_climatizador("calentando") -> "calentando"
+- VEC-008: mostrar_estado_completo con ConnectionError no propaga excepcion
+- VEC-009: timestamp en formato ISO 8601
+"""
+import json
+import pytest
+from unittest.mock import Mock, patch
+from agentes_actuadores.visualizador_estado_consolidado import VisualizadorEstadoConsolidadoSocket
+
+
+@pytest.fixture
+def gestores():
+    """Mocks de los tres gestores con valores por defecto"""
+    ambiente = Mock()
+    ambiente.obtener_temperatura_ambiente.return_value = 22.5
+    ambiente.obtener_temperatura_deseada.return_value = 24.0
+    ambiente.ambiente.temperatura_a_mostrar = "ambiente"
+
+    climatizador = Mock()
+    climatizador.obtener_estado_climatizador.return_value = "calentando"
+
+    bateria = Mock()
+    bateria.obtener_indicador_de_carga.return_value = "NORMAL"
+
+    return ambiente, climatizador, bateria
+
+
+@pytest.fixture
+def mock_socket():
+    """Socket cliente mockeado"""
+    return Mock()
+
+
+class TestVisualizadorEstadoConsolidadoConstructor:
+
+    # VEC-001
+    def test_constructor_almacena_host_y_puerto(self):
+        """El constructor almacena host y puerto correctamente"""
+        vis = VisualizadorEstadoConsolidadoSocket("192.168.1.1", 9000)
+        assert vis._host == "192.168.1.1"
+        assert vis._port == 9000
+
+    def test_constructor_valores_por_defecto(self):
+        """El constructor tiene valores por defecto (localhost, 14001)"""
+        vis = VisualizadorEstadoConsolidadoSocket()
+        assert vis._host == "localhost"
+        assert vis._port == 14001
+
+
+class TestVisualizadorEstadoConsolidadoEnvio:
+
+    # VEC-002
+    def test_mostrar_estado_conecta_y_envia_bytes(self, gestores, mock_socket):
+        """mostrar_estado_completo conecta al socket y envia bytes"""
+        ambiente, climatizador, bateria = gestores
+        vis = VisualizadorEstadoConsolidadoSocket("localhost", 14001)
+
+        with patch("socket.socket", return_value=mock_socket), \
+             patch("time.sleep"):
+            vis.mostrar_estado_completo(ambiente, climatizador, bateria)
+
+        mock_socket.connect.assert_called_once_with(("localhost", 14001))
+        mock_socket.send.assert_called_once()
+        mock_socket.close.assert_called_once()
+
+    # VEC-003
+    def test_json_contiene_8_campos_requeridos(self, gestores, mock_socket):
+        """El JSON enviado contiene los 8 campos del contrato de API"""
+        ambiente, climatizador, bateria = gestores
+        vis = VisualizadorEstadoConsolidadoSocket()
+        campos_requeridos = {
+            "temperatura_actual", "temperatura_deseada", "modo_climatizador",
+            "falla_sensor", "bateria_baja", "encendido", "modo_display", "timestamp"
+        }
+
+        with patch("socket.socket", return_value=mock_socket), \
+             patch("time.sleep"):
+            vis.mostrar_estado_completo(ambiente, climatizador, bateria)
+
+        bytes_enviados = mock_socket.send.call_args[0][0]
+        estado = json.loads(bytes_enviados.decode("utf-8").strip())
+        assert campos_requeridos == set(estado.keys())
+
+    # VEC-008
+    def test_connection_error_no_propaga_excepcion(self, gestores):
+        """Cuando el socket falla con ConnectionError, no propaga la excepcion"""
+        ambiente, climatizador, bateria = gestores
+        vis = VisualizadorEstadoConsolidadoSocket()
+        mock_s = Mock()
+        mock_s.connect.side_effect = ConnectionError("refused")
+
+        with patch("socket.socket", return_value=mock_s), \
+             patch("time.sleep"):
+            vis.mostrar_estado_completo(ambiente, climatizador, bateria)  # No debe lanzar
+
+
+class TestVisualizadorConstruirEstado:
+
+    # VEC-004
+    def test_temperatura_none_activa_falla_sensor(self):
+        """Cuando temperatura_actual es None, falla_sensor=True y temp_actual=0.0"""
+        ambiente = Mock()
+        ambiente.obtener_temperatura_ambiente.return_value = None
+        ambiente.obtener_temperatura_deseada.return_value = 24.0
+        ambiente.ambiente.temperatura_a_mostrar = "ambiente"
+        climatizador = Mock()
+        climatizador.obtener_estado_climatizador.return_value = "apagado"
+        bateria = Mock()
+        bateria.obtener_indicador_de_carga.return_value = "NORMAL"
+
+        vis = VisualizadorEstadoConsolidadoSocket()
+        estado = vis._construir_estado(ambiente, climatizador, bateria)
+
+        assert estado["falla_sensor"] is True
+        assert estado["temperatura_actual"] == 0.0
+
+    # VEC-005
+    def test_bateria_baja_activa_flag(self):
+        """Cuando indicador de carga es BAJA, bateria_baja=True"""
+        ambiente = Mock()
+        ambiente.obtener_temperatura_ambiente.return_value = 22.0
+        ambiente.obtener_temperatura_deseada.return_value = 24.0
+        ambiente.ambiente.temperatura_a_mostrar = "ambiente"
+        climatizador = Mock()
+        climatizador.obtener_estado_climatizador.return_value = "calentando"
+        bateria = Mock()
+        bateria.obtener_indicador_de_carga.return_value = "BAJA"
+
+        vis = VisualizadorEstadoConsolidadoSocket()
+        estado = vis._construir_estado(ambiente, climatizador, bateria)
+
+        assert estado["bateria_baja"] is True
+
+    # VEC-009
+    def test_timestamp_formato_iso_8601(self, gestores):
+        """El campo timestamp tiene formato ISO 8601"""
+        ambiente, climatizador, bateria = gestores
+        vis = VisualizadorEstadoConsolidadoSocket()
+        estado = vis._construir_estado(ambiente, climatizador, bateria)
+        # ISO 8601 contiene 'T' separando fecha y hora
+        assert "T" in estado["timestamp"]
+        assert len(estado["timestamp"]) >= 19  # YYYY-MM-DDTHH:MM:SS
+
+
+class TestMapearModoClimatizador:
+
+    # VEC-006
+    def test_apagado_mapea_a_reposo(self):
+        """'apagado' se mapea a 'reposo'"""
+        assert VisualizadorEstadoConsolidadoSocket._mapear_modo_climatizador("apagado") == "reposo"
+
+    # VEC-007
+    def test_calentando_sin_cambio(self):
+        """'calentando' se mantiene como 'calentando'"""
+        assert VisualizadorEstadoConsolidadoSocket._mapear_modo_climatizador("calentando") == "calentando"
+
+    def test_enfriando_sin_cambio(self):
+        """'enfriando' se mantiene como 'enfriando'"""
+        assert VisualizadorEstadoConsolidadoSocket._mapear_modo_climatizador("enfriando") == "enfriando"
+
+    def test_desconocido_mapea_a_reposo(self):
+        """Un estado desconocido se mapea a 'reposo' como fallback"""
+        assert VisualizadorEstadoConsolidadoSocket._mapear_modo_climatizador("otro") == "reposo"


### PR DESCRIPTION
## Resumen

Fase B del plan de cobertura de testing. Cubre la capa de Interface Adapters: visualizadores, proxies socket y el visualizador de estado consolidado.

## Actividades

| Commit | Actividad | Tests nuevos |
|--------|-----------|-------------|
| B-1 | Visualizadores batería y climatizador — consola, socket y API (VIS-B-001..006, VIS-C-001..005) | 13 |
| B-2 | Proxies seteo y batería socket — consola, socket, context manager (PRX-SET-001..005, PRX-SNS-001, PRX-BAT-001) | 9 |
| B-3 | VisualizadorEstadoConsolidadoSocket — JSON, 8 campos contrato, falla_sensor, bateria_baja, timestamp (VEC-001..009) | 12 |

## Cobertura estimada

72% → 80% (+8%)

## Test plan

- [x] 252 tests pasando (`pytest Test/ -q`)
- [x] Sin tests rotos ni skipped
- [x] Sockets mockeados con `patch("socket.socket")` — sin puertos reales abiertos
- [x] `time.sleep` mockeado en tests de VisualizadorEstadoConsolidado

🤖 Generated with [Claude Code](https://claude.com/claude-code)